### PR TITLE
fix error with reversed params for run-python

### DIFF
--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -1613,7 +1613,7 @@ It should be possible to support python-mode.el.  Patches are welcome!
              ;; python.el makes dedicated process when
              ;; `buffer-file-name' has some value.
              (buffer-file-name (buffer-name)))
-        (run-python t (python-shell-parse-command))
+        (run-python (python-shell-parse-command) t)
         (python-shell-switch-to-shell))
     (ein:log 'warn "python.el is not loaded!")))
 


### PR DESCRIPTION
Signature for `run-python` is:

```
(run-python CMD &optional DEDICATED SHOW)
```

The code was set to:

```
(run-python t (python-shell-parse-command))
```

But it should be:

```
(run-python (python-shell-parse-command) t)
```
