### PR TITLE
Use request.el

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,17 @@ log-clean:
 	rm -rf log
 
 travis-ci-testein: ert-compile env-ipy.$(IPY_VERSION)
+	${MAKE} testein-2
+
+testein-2: testein-2-url-retrieve testein-2-curl
+
+testein-2-curl:
+	EL_REQUEST_BACKEND=curl ${MAKE} testein-1
+
+testein-2-url-retrieve:
+	EL_REQUEST_BACKEND=url-retrieve ${MAKE} testein-1
+
+testein-1:
 	$(EMACS) --version
 	python --version
 	env/ipy.$(IPY_VERSION)/bin/ipython --version

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ Requirements
 
 * IPython_ 0.12 or higher.
 * `websocket.el`_ 0.9
+* `request.el`_ >= 0.2
 * (optional) mumamo_ developmental version:
   It will be automatically loaded when it is on the path.
   The official way to setup path is to load nXhtml_.
@@ -126,6 +127,7 @@ It is known to work in Emacs 23.2, 24.1 and 24.2.
 
 .. _IPython: http://ipython.org/
 .. _websocket.el: https://github.com/ahyatt/emacs-websocket
+.. _request.el: https://github.com/tkf/emacs-request
 .. _mumamo: http://www.emacswiki.org/emacs/MuMaMo
 .. _nXhtml: http://ourcomments.org/Emacs/nXhtml/doc/nxhtml.html
 .. _python.el: https://github.com/fgallina/python.el

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -87,6 +87,7 @@ Requirements
 
 * IPython_ 0.12 or higher.
 * `websocket.el`_ 0.9
+* `request.el`_ >= 0.2
 * (optional) mumamo_ developmental version:
   It will be automatically loaded when it is on the path.
   The official way to setup path is to load nXhtml_.
@@ -110,6 +111,7 @@ It is known to work in Emacs 23.2, 24.1 and 24.2.
 
 .. _IPython: http://ipython.org/
 .. _websocket.el: https://github.com/ahyatt/emacs-websocket
+.. _request.el: https://github.com/tkf/emacs-request
 .. _mumamo: http://www.emacswiki.org/emacs/MuMaMo
 .. _nXhtml: http://ourcomments.org/Emacs/nXhtml/doc/nxhtml.html
 .. _python.el: https://github.com/fgallina/python.el
@@ -541,6 +543,11 @@ with :el:symbol:`ein:dev-stop-debug`.
 
 Change Log
 ==========
+
+v0.2.1
+------
+
+* Use request.el_ for smoother experience.
 
 v0.2
 ----

--- a/lisp/ein-dev.el
+++ b/lisp/ein-dev.el
@@ -218,7 +218,7 @@ callback (`websocket-callback-debug-on-error') is enabled."
                 (ein:dev-dump-vars '("source-dir")))
    :lib (ein:filter (lambda (info) (plist-get info :path))
                     (mapcar #'ein:dev-sys-info--lib
-                            '("websocket" "auto-complete" "mumamo"
+                            '("websocket" "request" "auto-complete" "mumamo"
                               "auto-complete" "popup" "fuzzy" "pos-tip"
                               "python" "python-mode" "markdown-mode"
                               "smartrep" "anything" "helm")))))

--- a/lisp/ein-dev.el
+++ b/lisp/ein-dev.el
@@ -214,6 +214,7 @@ callback (`websocket-callback-debug-on-error') is enabled."
    :image-types (ein:eval-if-bound 'image-types)
    :image-types-available (ein:filter #'image-type-available-p
                                       (ein:eval-if-bound 'image-types))
+   :request (list :backend request-backend)
    :ein (append (list :version (ein:version))
                 (ein:dev-dump-vars '("source-dir")))
    :lib (ein:filter (lambda (info) (plist-get info :path))

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -238,24 +238,14 @@ This function is called via `ein:notebook-after-rename-hook'."
                  &aux
                  (no-popup t)
                  (error (request-response-error-thrown response))
-                 (redirects (request-response-redirects response))
-                 (redirect (car (last redirects))))
+                 (dest (request-response-url response)))
   (ein:log 'verbose
-    "NOTEBOOKLIST-NEW-NOTEBOOK-ERROR url-or-port: %S; error: %S; redirects: %S"
-    url-or-port error redirects)
-  (if redirect
-      ;; Workaround the redirection bug in `url-retrieve'.
-      ;; See: http://debbugs.gnu.org/cgi/bugreport.cgi?bug=12374
-      (let ((notebook-id
-             (ein:trim
-              (url-filename (url-generic-parse-url redirect)) "/")))
-        (ein:log 'info "Creating a new notebook... Done.")
-        (ein:notebook-open url-or-port notebook-id callback cbargs))
-    (ein:log 'error
-      (concat "Failed to open new notebook (error: %S). "
-              "You may find the new one in the notebook list.")
-      error)
-    (setq no-popup nil))
+    "NOTEBOOKLIST-NEW-NOTEBOOK-ERROR url-or-port: %S; error: %S; dest: %S"
+    url-or-port error dest)
+  (ein:log 'error
+    "Failed to open new notebook (error: %S). \
+You may find the new one in the notebook list." error)
+  (setq no-popup nil)
   (ein:notebooklist-open url-or-port no-popup))
 
 ;;;###autoload

--- a/lisp/ein-org.el
+++ b/lisp/ein-org.el
@@ -79,7 +79,8 @@ S-expression based (rather verbose) serialization, so that
 extending link spec without loosing backward compatibility is
 easier.  For the examples of link format in general, see Info
 node `(org) External links' and Info node `(org) Search options'"
-  (ein:and-let* ((notebook (ein:get-notebook))
+  (ein:and-let* (((ein:worksheet-buffer-p))
+                 (notebook (ein:get-notebook))
                  (name (ein:notebook-name notebook))
                  (link (list :url-or-port (ein:get-url-or-port)
                              :name name))

--- a/lisp/ein-pkg.el
+++ b/lisp/ein-pkg.el
@@ -2,6 +2,6 @@
   "0.2.0alpha0"
   "Emacs IPython Notebook"
   '((websocket "0.9")
-    (request "0.1")
+    (request "0.2")
     ;; `auto-complete' is not really a dependency, but who use EIN w/o AC?
     (auto-complete "1.4")))

--- a/tests/func-test.el
+++ b/tests/func-test.el
@@ -6,6 +6,11 @@
 (require 'ein-testing)
 (require 'ein-testing-cell)
 
+(let ((backend (getenv "EL_REQUEST_BACKEND")))
+  (when (and backend (not (equal backend "")))
+    (setq request-backend (intern backend))
+    (message "Using request-backend = %S" request-backend)))
+
 (ein:setq-if-not ein:testing-dump-file-log "func-test-batch-log.log")
 (ein:setq-if-not ein:testing-dump-file-messages "func-test-batch-messages.log")
 (setq message-log-max t)


### PR DESCRIPTION
Use request.el (https://github.com/tkf/emacs-request) to avoid bugs in url.el.

This branch passes the test:
https://travis-ci.org/tkf/emacs-ipython-notebook/builds/3872279
But I need to test it in real use more before merge.  Probably I should add more unit/functional tests.

I think it is usable.  If you are courageous please use it and report bug if you find it.

---

Check list before merge:
- Make sure that request.el is installable from MELPA
- Add request.el as a dependency in el-get recipe
